### PR TITLE
iitc botguard interface: i've had a chance to test a real-world case of ...

### DIFF
--- a/code/botguard_interface.js
+++ b/code/botguard_interface.js
@@ -115,14 +115,14 @@ iitc_bg.process_key = function(key,serverEval) {
       // however... reports say that it only interacts with the botguard.bg code, so we might be fine just running it
       // (but this is only when we don't send the correct params to the server? no reports of this code triggering yet...)
       try {
-        console.warn('Server-generated javascript eval requested:\n'+serverExec);
-debugger;
-if (!confirm('The server asked IITC to run (eval) some javascript. This may or may not be safe. Run and continue?\n\nScript:\n'+serverEval)) { console.error('server javascript eval cancelled') } else
+        console.warn('botguard: Server-generated javascript eval requested:\n'+serverEval);
+//debugger;
+//if (!confirm('The server asked IITC to run (eval) some javascript. This may or may not be safe. Run and continue?\n\nScript:\n'+serverEval)) { console.error('server javascript eval cancelled') } else
         iitc_bg.evalFunc(serverEval);
-console.log('Server-generated javascript ran OK');
+        console.log('botguard: Server-generated javascript ran OK');
       } catch(e) {
-console.warn('Server-generated javascript - threw an exception');
-console.warn(e);
+        console.warn('botguard: Server-generated javascript - threw an exception');
+        console.warn(e);
         noCatch = false;
       }
     }


### PR DESCRIPTION
...the server asking the client to run a script, which is when it switches to a new key

seems OK, so remove the user prompt - it will break badly if declined. logging remains, to help diagnose issues
also fix silly typo that prevented it from actually working right :)