### PR TITLE
portal mod stats: convert the new large removal stickiness values to a p...

### DIFF
--- a/code/portal_detail_display_tools.js
+++ b/code/portal_detail_display_tools.js
@@ -115,6 +115,7 @@ window.getModDetails = function(d) {
           else if (key === 'ATTACK_FREQUENCY')      val = (val/1000) +'x'; // 2000 = 2x
           else if (key === 'FORCE_AMPLIFIER')       val = (val/1000) +'x'; // 2000 = 2x
           else if (key === 'LINK_RANGE_MULTIPLIER') val = (val/1000) +'x'; // 2000 = 2x
+          else if (key === 'REMOVAL_STICKINESS' && val > 100) val = (val/10000)+'%'; // an educated guess
           // else display unmodified. correct for shield mitigation and multihack - unknown for future/other mods
 
           modTooltip += '\n+' +  val + ' ' + key.capitalize().replace(/_/g,' ');


### PR DESCRIPTION
...ercentage. there's no confirmation from Niantic this is what it means, and unlikely to ever be any exapanation, but it folows the convention used for other high value mod stats

low values (<=100) are displayed as-is, for existing portals. it's unknown how the backend servers actually handle a mix of old and new mods