### PR TITLE
ignore portals returned in the map data that are below the portal level ...

### DIFF
--- a/code/map_data_request.js
+++ b/code/map_data_request.js
@@ -230,7 +230,7 @@ window.MapDataRequest.prototype.refresh = function() {
   this.render.startRenderPass(tileParams.level, dataBounds);
 
 
-  this.render.processGameEntities(artifact.getArtifactEntities());
+  this.render.processGameEntities(artifact.getArtifactEntities(),true);
 
   var logMessage = 'requesting data tiles at zoom '+dataZoom;
   if (tileParams.level != tileParams.maxLevel) {


### PR DESCRIPTION
...requested

this shouldn't be needed - the stock intel map completely ignores these so they shouldn't be returned - but since niantic added mission portals to the map they bypass all portal level filtering code, for some reason